### PR TITLE
Patch 4

### DIFF
--- a/logic/lab_past_entrances.yaml
+++ b/logic/lab_past_entrances.yaml
@@ -87,7 +87,7 @@ crescent past E: {or: [
   outer past - crescent - shop,
   outer past - crescent - E house,
   outer past - crescent - SE cave,
-  [outer past - crescent - E stairs after boulder, bracelet],
+  [outer past - crescent - E stairs after boulder, or: [bracelet, ages,[gale satchel, currents]]],
   [crescent present E, echoes]
 ]}
 crescent past NW: {or: [
@@ -121,7 +121,7 @@ outer past - crescent - L coconut separated cave: {or: [crescent past SW]}
 outer past - crescent - R coconut separated cave: {or: [crescent past S]}
 outer past - crescent - SE cave: {or: [crescent past E]}
 outer past - crescent - E house: {or: [crescent past E]}
-outer past - crescent - E stairs after boulder: {or: [[crescent past E, bracelet]]}
+outer past - crescent - E stairs after boulder: {or: [[crescent past E, bracelet],[crescent present E,ages]}
 
 inner past - crescent - shop: {or: []}
 inner past - crescent - face cave: {or: [

--- a/logic/lab_past_entrances.yaml
+++ b/logic/lab_past_entrances.yaml
@@ -250,6 +250,7 @@ outer past - mid goron - sword game: {or: [[goron present mid top, or: [ages, [b
 outer past - mid goron - near seed tree: {or: [
   [goron present mid bottom, ages],
   [non-entrance, outer past - mid goron - sword game]
+  [outer past mid goron SW of bomb cave, gale satchel]
 ]}
 
 inner past - mid goron - SW of bomb cave: {or: [

--- a/logic/lab_past_entrances.yaml
+++ b/logic/lab_past_entrances.yaml
@@ -121,7 +121,7 @@ outer past - crescent - L coconut separated cave: {or: [crescent past SW]}
 outer past - crescent - R coconut separated cave: {or: [crescent past S]}
 outer past - crescent - SE cave: {or: [crescent past E]}
 outer past - crescent - E house: {or: [crescent past E]}
-outer past - crescent - E stairs after boulder: {or: [[crescent past E, bracelet],[crescent present E,ages]}
+outer past - crescent - E stairs after boulder: {or: [[crescent past E, bracelet],[crescent present E,ages]]}
 
 inner past - crescent - shop: {or: []}
 inner past - crescent - face cave: {or: [

--- a/logic/lab_past_entrances.yaml
+++ b/logic/lab_past_entrances.yaml
@@ -177,7 +177,7 @@ outer past - crescent - SE cave: {or: [crescent past E]}
 outer past - crescent - E house: {or: [crescent past E]}
 outer past - crescent - E stairs after boulder: {or: [
     [crescent past E, bracelet],
-    [crescent present E,ages]
+    [crescent present E, ages]
 ]}
 
 inner past - crescent - shop: {or: []}

--- a/logic/lab_present_entrances.yaml
+++ b/logic/lab_present_entrances.yaml
@@ -83,7 +83,9 @@ crescent present W: {or: [
   dimitri's flute, open sea present,
   all crescent,
   [currents, or: [crescent past NW, crescent past SW]],
-  [shovel, echoes, crescent past SW]
+  [shovel, echoes, crescent past SW],
+  outer d3,
+  outer present - crescent - SW cave
 ]}
 outer present - crescent - NE cave: {or: [crescent present E]}
 outer present - crescent - E house: {or: [crescent present E]}

--- a/logic/lab_present_entrances.yaml
+++ b/logic/lab_present_entrances.yaml
@@ -212,7 +212,7 @@ goron lower present: {or: [
   outer present - lower goron - d6 cave,
   outer present - lower goron - dance cave,
   outer present - lower goron - cave beside dance cave,
-  [non-entrance, goron present mid bottom],
+  [or:[non-entrance, gale satchel] goron present mid bottom],
   [currents, or: [goron lower past W, goron lower past E]]
 ]}
 outer present - lower goron old man: {or: [[goron lower present, ember seeds]]}

--- a/logic/lab_present_entrances.yaml
+++ b/logic/lab_present_entrances.yaml
@@ -98,8 +98,8 @@ crescent present E: {or: [
     all crescent,
     [crescent past E, echoes],
     [outer past - crescent - E stairs after boulder, or: [
-      ages,
-      [currents, gale satchel]]]
+        ages,
+        [currents, gale satchel]]]
     [currents, or: [
         crescent past NW, 
         crescent past S]]


### PR DESCRIPTION
Changes:
Actually added logic for reaching Crescent Island West Present, from the entrances there, which wasn't always the case.
Logic for reaching crescent island stairs after boulder, without bracelet, via tune of ages, and vice versa (using only currents there past to present, can actually be a softlock if you then currents elsewhere, moving your portal, leaving you unable to get back to the stairway, which is why it requires gales for currents)
There's logic for reaching the seed tree in mid right rolling ridge via gale satchel, but oddly not for the entrance in the same place. Fixed that.
And finally, just one of many to be done, just as an idea, added logic for dropping down a ledge, if you have gales to guarantee getting back up. Of course, with all of your softlock prevention map changes, this last one might not be needed, but it's still an idea.